### PR TITLE
Adding extra_verbose_names to the admin actions.

### DIFF
--- a/tabular_export/admin.py
+++ b/tabular_export/admin.py
@@ -39,9 +39,9 @@ def ensure_filename(suffix):
 
 
 @ensure_filename('xlsx')
-def export_to_excel_action(modeladmin, request, queryset, filename=None, field_names=None):
+def export_to_excel_action(modeladmin, request, queryset, filename=None, field_names=None, extra_verbose_names=None):
     """Django admin action which exports selected records as an Excel XLSX download"""
-    headers, rows = flatten_queryset(queryset, field_names=field_names)
+    headers, rows = flatten_queryset(queryset, field_names=field_names, extra_verbose_names=extra_verbose_names)
     return export_to_excel_response(filename, headers, rows)
 
 
@@ -49,9 +49,9 @@ export_to_excel_action.short_description = _('Export to Excel')
 
 
 @ensure_filename('csv')
-def export_to_csv_action(modeladmin, request, queryset, filename=None, field_names=None):
+def export_to_csv_action(modeladmin, request, queryset, filename=None, field_names=None, extra_verbose_names=None):
     """Django admin action which exports the selected records as a CSV download"""
-    headers, rows = flatten_queryset(queryset, field_names=field_names)
+    headers, rows = flatten_queryset(queryset, field_names=field_names, extra_verbose_names=extra_verbose_names)
     return export_to_csv_response(filename, headers, rows)
 
 


### PR DESCRIPTION
Added the ability to optionally pass extra_verbose_names to the admin actions. Added a test for that functionality.

We'd like to use this functionality in the Concordia project (https://github.com/LibraryOfCongress/concordia), which uses this library.